### PR TITLE
Update boot.sh

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 check=$(irecovery -q | grep CPID | sed 's/CPID: //')
 


### PR DESCRIPTION
The file, "boot.sh," uses a bash file that does not exist, at least in macOS Monterey To fix this, I edited the shell script to use the /bin/bash executable instead of the /usr/bin/bash executable, which doesn't exist. 